### PR TITLE
Reset inputs

### DIFF
--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -108,7 +108,7 @@ class Dashboard extends Component {
         }
         let elem = document.querySelector(modal);
         let options = {
-            // dismissible: false
+            dismissible: false
         }
         M.Modal.init(elem, options);
         let instance = M.Modal.getInstance(elem);
@@ -255,11 +255,17 @@ class Dashboard extends Component {
                 handleDeleteCategory={this.handleDeleteCategory}/>
                 <Chores chores={this.state.chores} getChores={this.getChores} users={this.state.users}
                 handleOpenModal={this.handleOpenModal} handleCloseModal={this.handleCloseModal}/>
-                <AddCategoryModal addNewCategory={this.addNewCategory}/>
+                <AddCategoryModal addNewCategory={this.addNewCategory} handleCloseModal={this.handleCloseModal}/>
                 <AddChoreModal getChores={this.getChores} handleCloseModal={this.handleCloseModal}/>
 
                 <div id="modal1" className="modal editModal modal-fixed-footer">
                     <div className="modal-content">
+                        <div className='row'>
+                            <i className="material-icons right"
+                            onClick={() => this.handleCloseModal('.editModal')}
+                            >close</i>
+                        </div>
+
                         <div className='row'>
                             <div className='col s8 offset-s2'>
                                 <input type="text" name="categoryName" id="categoryName" 
@@ -297,6 +303,11 @@ class Dashboard extends Component {
                         </div>
                     </div>
                     <div className="modal-footer">
+                        <button className="btn left red" 
+                            onClick={() => this.handleCloseModal('.editModal')}>
+                                Cancel
+                        </button>
+
                         <a href="#!" className="modal-close waves-effect waves-green btn-flat"
                         onClick={(e) => {this.handleEditCategory(e, this.state.users, this.state.categoryName)}}
                         disabled={this.state.editSaveBtnDisabled}>Save</a>

--- a/src/components/dashboard/addCategoryModal/AddCategoryModal.js
+++ b/src/components/dashboard/addCategoryModal/AddCategoryModal.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import AddUserInput from './addUserInput/AddUserInput';
 import '../addCategoryModal/addCategoryModal.css';
+import M from "materialize-css";
 const baseUrl = process.env.REACT_APP_BASE_URL || 'http://localhost:8080';
 
 class AddCategoryModal extends Component {
@@ -66,13 +67,25 @@ class AddCategoryModal extends Component {
         }
     }
 
+    handleCloseAddCategoryModal(modal) {
+        this.setState({
+            addUserInputs: [],
+            categoryNameInput: ''
+        });
+
+        let elem = document.querySelector(modal);
+        M.Modal.init(elem, {});
+        let instance = M.Modal.getInstance(elem);
+        instance.close();
+    }
+
     render() {
         return (
             <div id="modal1" className="modal addModal modal-fixed-footer">
                 <div className="modal-content">
                     <div className='row'>
                         <i className="material-icons right"
-                        onClick={() => this.props.handleCloseModal('.addModal')}
+                        onClick={() => this.handleCloseAddCategoryModal('.addModal')}
                         >close</i>
                     </div>
                     <div className='row'>
@@ -97,7 +110,7 @@ class AddCategoryModal extends Component {
                 </div>
                 <div className="modal-footer">
                     <button className="btn left red" 
-                        onClick={() => this.props.handleCloseModal('.addModal')}>
+                        onClick={() => this.handleCloseAddCategoryModal('.addModal')}>
                             Cancel
                     </button>
 

--- a/src/components/dashboard/addCategoryModal/AddCategoryModal.js
+++ b/src/components/dashboard/addCategoryModal/AddCategoryModal.js
@@ -71,6 +71,11 @@ class AddCategoryModal extends Component {
             <div id="modal1" className="modal addModal modal-fixed-footer">
                 <div className="modal-content">
                     <div className='row'>
+                        <i className="material-icons right"
+                        onClick={() => this.props.handleCloseModal('.addModal')}
+                        >close</i>
+                    </div>
+                    <div className='row'>
                         <div className='col s8 offset-s2'>
                             <input placeholder='Category Name' type="text" name="categoryName" id="categoryName" 
                             value={this.state.categoryNameInput}
@@ -91,6 +96,11 @@ class AddCategoryModal extends Component {
                     </div>
                 </div>
                 <div className="modal-footer">
+                    <button className="btn left red" 
+                        onClick={() => this.props.handleCloseModal('.addModal')}>
+                            Cancel
+                    </button>
+
                     <a href="#!" className="modal-close waves-effect waves-green btn-flat"
                     onClick={(e) => {this.handleSaveCategory(e, this.state.addUserInputs, this.state.categoryNameInput)}}
                     >Save</a>

--- a/src/components/dashboard/addChoreModal/AddChoreModal.js
+++ b/src/components/dashboard/addChoreModal/AddChoreModal.js
@@ -131,6 +131,10 @@ class addChoreModal extends Component{
             <div id="modal1" className="modal addChoreModal modal-fixed-footer">
                 <div className="modal-content">
 
+                    <i className="material-icons right"
+                    onClick={() => this.props.handleCloseModal('.addChoreModal')}
+                    >close</i>
+
                     <div className='row addChoreForm'>
                     <input placeholder='Chore Name' type="text" name="choreName" id="choreName" 
                             value={this.state.choreName}
@@ -195,6 +199,11 @@ class addChoreModal extends Component{
 
                     <textarea value={this.state.choreNotes} onChange={this.handleAddNote}></textarea>
                     <label>Notes</label>
+
+                    <button className="btn left red" 
+                        onClick={() => this.props.handleCloseModal('.addChoreModal')}>
+                            Cancel
+                    </button>
 
                     <button className={this.state.choreName && this.state.choreStatus && this.state.choreCategoryId 
                     ? 'btn right' : 'btn right disabled'}

--- a/src/components/dashboard/addChoreModal/AddChoreModal.js
+++ b/src/components/dashboard/addChoreModal/AddChoreModal.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import M from "materialize-css";
 const baseUrl = process.env.REACT_APP_BASE_URL || 'http://localhost:8080';
 
 class addChoreModal extends Component{
@@ -126,13 +127,31 @@ class addChoreModal extends Component{
         }
     }
 
+    handleCloseAddChoreModal(modal) {
+        this.setState({
+            choreAssigneeUsername: '',
+            choreCategoryId: '',
+            choreName: '',
+            choreDateComplete: '',
+            choreDifficulty: '',
+            choreFreqId: '',
+            choreNotes: '',
+            choreStatus: ''   
+        });
+        
+        let elem = document.querySelector(modal);
+        M.Modal.init(elem, {});
+        let instance = M.Modal.getInstance(elem);
+        instance.close();
+    }
+
     render() {
         return (
             <div id="modal1" className="modal addChoreModal modal-fixed-footer">
                 <div className="modal-content">
 
                     <i className="material-icons right"
-                    onClick={() => this.props.handleCloseModal('.addChoreModal')}
+                    onClick={() => this.handleCloseAddChoreModal('.addChoreModal')}
                     >close</i>
 
                     <div className='row addChoreForm'>
@@ -201,7 +220,7 @@ class addChoreModal extends Component{
                     <label>Notes</label>
 
                     <button className="btn left red" 
-                        onClick={() => this.props.handleCloseModal('.addChoreModal')}>
+                        onClick={() => this.handleCloseAddChoreModal('.addChoreModal')}>
                             Cancel
                     </button>
 

--- a/src/components/dashboard/chores/Chores.js
+++ b/src/components/dashboard/chores/Chores.js
@@ -212,7 +212,7 @@ class Chores extends Component {
                 <div className="modal-content">
 
                     <i className="material-icons right"
-                    onClick={this.handleCloseChoreModal}
+                    onClick={() => this.props.handleCloseModal('.choreModal')}
                     >close</i>
 
                     <div className='row choreEditForm'>

--- a/src/components/dashboard/chores/Chores.js
+++ b/src/components/dashboard/chores/Chores.js
@@ -29,6 +29,9 @@ class Chores extends Component {
     handleChoreClick(event, modal, chore) {
         event.preventDefault();
         let elem = document.querySelector(modal);
+        let options = {
+            dismissible: false
+        }
         this.getUserById(chore.assignee_id);
         this.currentChore = chore; 
 
@@ -47,7 +50,7 @@ class Chores extends Component {
             detailsBool: !this.state.detailsBool
         });
         
-        M.Modal.init(elem, {});
+        M.Modal.init(elem, options);
         let instance = M.Modal.getInstance(elem);
         instance.open();
     }
@@ -284,6 +287,11 @@ class Chores extends Component {
                         <button className="btn left red" 
                             onClick={(e) => this.handleDeleteChore(e, this.currentChore.id)}>
                                 <i className="material-icons deleteChoreIcon">delete</i>
+                        </button>
+
+                        <button className="btn left red" 
+                            onClick={() => this.props.handleCloseModal('.choreModal')}>
+                                Cancel
                         </button>
 
                         <button className={!this.state.choreName ? "btn right disabled" : "btn right"} 


### PR DESCRIPTION
**FE - Reset Inputs for add category & chore modals**
- [x] Update open modal, options object
- [x] Add cancel btn & 'x' btn to add category modal
- [x] Add cancel btn & 'x' btn to add chore modal
- [x] Add cancel btn & 'x' btn to edit category modal
- [x] Make edit chore dismissable: false
- [x] Create handleCloseModal function:
  - in dashboard and pass down as prop?
  - separate in each component and reset state to empty inputs?